### PR TITLE
DebugDrawer does not take a scene argument

### DIFF
--- a/packages/recast-navigation-three/README.md
+++ b/packages/recast-navigation-three/README.md
@@ -95,7 +95,7 @@ This package provides a `DebugDrawer` utility that can visualise a navmesh and o
 ```ts
 import { DebugDrawer } from 'recast-navigation/three';
 
-const debugDrawer = new DebugDrawer({ scene });
+const debugDrawer = new DebugDrawer();
 
 // resize the debug drawer when the window resizes
 // required for rendering lines correctly


### PR DESCRIPTION
Seems like the DebugDrawer does not take a scene argument. As copied from the example here https://github.com/isaac-mason/recast-navigation-js/blob/main/packages/recast-navigation/.storybook/stories/debug/debug-drawer.stories.tsx#L67